### PR TITLE
Update NewRelic agent version and clean up library

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ func DefaultConfig(appName string) *InstrumentsConfig {
 
 	return &InstrumentsConfig{
 		StatsRecorder: recorder,
-		Tracer:        HasNewRelic{Application: &nr},
+		Tracer:        nr,
 	}
 }
 
@@ -43,6 +43,8 @@ func setupNewRelic(appName string) newrelic.Application {
 	}
 
 	config := newrelic.NewConfig(newrelicName, newrelicKey)
+	config.CrossApplicationTracer.Enabled = false
+	config.DistributedTracer.Enabled = true
 
 	if checkBool(shouldDisable) {
 		config.Enabled = false

--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@ package instrument
 
 import (
 	log "github.com/sirupsen/logrus"
-	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent"
 	"github.com/newrelic/go-agent/_integrations/nrlogrus"
 	"github.com/seatgeek/telemetria"
 	"os"
@@ -37,6 +37,9 @@ func setupNewRelic(appName string) newrelic.Application {
 	newrelicKey := os.Getenv("NEW_RELIC_LICENSE")
 	newrelicName := os.Getenv("NEW_RELIC_NAME")
 	shouldDisable := os.Getenv("NEW_RELIC_DISABLE")
+
+	log.Info("license - name", newrelicKey, newrelicName)
+
 
 	if newrelicName == "" {
 		newrelicName = appName

--- a/config.go
+++ b/config.go
@@ -38,9 +38,6 @@ func setupNewRelic(appName string) newrelic.Application {
 	newrelicName := os.Getenv("NEW_RELIC_NAME")
 	shouldDisable := os.Getenv("NEW_RELIC_DISABLE")
 
-	log.Info("license - name", newrelicKey, newrelicName)
-
-
 	if newrelicName == "" {
 		newrelicName = appName
 	}

--- a/config.go
+++ b/config.go
@@ -28,8 +28,8 @@ func DefaultConfig(appName string) *InstrumentsConfig {
 	nr := setupNewRelic(appName)
 
 	return &InstrumentsConfig{
-		StatsRecorder: recorder,
-		Tracer:        nr,
+		statsRecorder: recorder,
+		app:           nr,
 	}
 }
 

--- a/instrument.go
+++ b/instrument.go
@@ -150,9 +150,6 @@ func (i *InstrumentsConfig) ServeHTTP(rw http.ResponseWriter, r *http.Request, n
 	txn := i.Tracer.StartTransaction(r.URL.Path, rw, r)
 	defer txn.End()
 
-	newrelic.WrapHandle()
-
-
 	txn.AddAttribute("query", r.URL.RawQuery)
 
 	name := r.Method + " " + numberRegex.ReplaceAllString(r.URL.Path, "*")

--- a/instrument.go
+++ b/instrument.go
@@ -47,44 +47,14 @@ type InstrumentsConfig struct {
 	StatsRecorder telemetria.Recorder
 
 	// The NewRelic implementation to use for tracking segments
-	Tracer NewRelic
+	Tracer newrelic.Application
 }
 
-// NewRelic encapsulates the single responsibility of creating a tracing transaction
-// out of a server request.
-type NewRelic interface {
-	//Creates a new transaction out of a custom name and the arguments of a server request
-	NewTransaction(string, http.ResponseWriter, *http.Request) Transaction
-}
-
-// Transaction encapsulates most of the idea of tracking information about a request.
-// a Transaction is started at the beginning of each request and closed immediately after.
-type Transaction interface {
-	// Store additional information for this request as a key-value pair
-	AddAttribute(string, string)
-
-	// Starts a sort of sub-stransaction attached to this one. Segments are used
-	// for timing blocks of code
-	StartSegment(name string) Segment
-
-	// Records that an error happened during this transaction
-	NoticeError(e error)
-
-	// Finishes the transaction and stores all the gathered data
-	End()
-}
 
 // Segment is a sort of sub-transaction that is used to time blocks of code
 type Segment interface {
 	// Stops the timer and records the results
 	End()
-}
-
-// NewRelicTransaction ins the implementation of Transaction using the NewRelic
-// library.
-type NewRelicTransaction struct {
-	// The New Relic Transaction
-	Txn newrelic.Transaction
 }
 
 // Instruments contains all the external facing methods that are relevant to
@@ -129,21 +99,19 @@ type Instruments interface {
 	// Proper implementations of this method will automatically end the transaction
 	// and the end of the method
 	WithOfflineTransaction(func(Instruments))
+
+	// GetTransaction
+	GetTransaction() newrelic.Transaction
 }
 
 type fullInstruments struct {
 	influxdb telemetria.Recorder
 
-	nrTransaction Transaction
+	nrTransaction newrelic.Transaction
 
 	txnName string
 
 	config *InstrumentsConfig
-}
-
-// HasNewRelic contains the newrelicApp and indicates it should be used for instrumentation
-type HasNewRelic struct {
-	Application *newrelic.Application
 }
 
 // WithoutNewRelic indicates that no new relic middleware instrumentation
@@ -153,83 +121,15 @@ type WithoutNewRelic struct{}
 // or during testing
 type NoTransaction struct{}
 
-// NewRelicSegment is the implementation of the Segment interface using New Relic
-// segments
-type NewRelicSegment struct {
-	Segment *newrelic.Segment
-}
-
 // NoSegment means that we are not actually tracking the block of code, even though
 // it was requested. This is useful for testing and for custom implementations
 // of Instruments
 type NoSegment struct{}
 
-// NewTransaction starts tracking the request from the client by giving it a custom
-// name and both the response and request structs.
-func (n HasNewRelic) NewTransaction(name string, rw http.ResponseWriter, r *http.Request) Transaction {
-	app := *n.Application
-	txn := app.StartTransaction(name, rw, r)
-
-	if r != nil && r.URL.Path == "/_status" {
-		txn.Ignore()
-	}
-
-	return NewRelicTransaction{Txn: txn}
-}
-
-// AddAttribute stores the key-value attribute for the transaction directly with
-// NewRelic without altering it.
-func (t NewRelicTransaction) AddAttribute(name string, value string) {
-	t.Txn.AddAttribute(name, value)
-}
-
-// End terminates the New Relic transaction
-func (t NewRelicTransaction) End() {
-	t.Txn.End()
-}
-
-// NoticeError uses the New Relic's underlying API to store the error associated
-// with the current transaction
-func (t NewRelicTransaction) NoticeError(e error) {
-	t.Txn.NoticeError(e)
-}
-
-// StartSegment starts a New Relic plain Segment
-func (t NewRelicTransaction) StartSegment(name string) Segment {
-	return NewRelicSegment{Segment: newrelic.StartSegment(t.Txn, name)}
-}
-
-// End terminates the New Relic segment
-func (s NewRelicSegment) End() {
-	s.Segment.End()
-}
-
-// NewTransaction returns a mocked Transaction
-func (n WithoutNewRelic) NewTransaction(name string, rw http.ResponseWriter, r *http.Request) Transaction {
-	return NoTransaction{}
-}
-
-// End does nothing
-func (n NoSegment) End() {}
-
-// AddAttribute does nothing
-func (t NoTransaction) AddAttribute(name string, value string) {}
-
-// End does nothing
-func (t NoTransaction) End() {}
-
-// NoticeError does nothing
-func (t NoTransaction) NoticeError(e error) {}
-
-// StartSegment returns a mocked Segment
-func (t NoTransaction) StartSegment(name string) Segment {
-	return NoSegment{}
-}
-
 // WithTransaction creates new Instruments associated with the passed transaction
 // that can be used from tracking various aspects of the application as long as
 // the transaction remains open
-func (i *InstrumentsConfig) WithTransaction(name string, txn Transaction) Instruments {
+func (i *InstrumentsConfig) WithTransaction(name string, txn newrelic.Transaction) Instruments {
 	return &fullInstruments{
 		influxdb:      i.StatsRecorder,
 		nrTransaction: txn,
@@ -247,8 +147,11 @@ func (i *fullInstruments) ServeHTTP(rw http.ResponseWriter, r *http.Request, nex
 // into the request context so that they can be used directly in each of the handlers
 // in the middleware stack
 func (i *InstrumentsConfig) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	txn := i.Tracer.NewTransaction(r.URL.Path, rw, r)
+	txn := i.Tracer.StartTransaction(r.URL.Path, rw, r)
 	defer txn.End()
+
+	newrelic.WrapHandle()
+
 
 	txn.AddAttribute("query", r.URL.RawQuery)
 
@@ -257,6 +160,7 @@ func (i *InstrumentsConfig) ServeHTTP(rw http.ResponseWriter, r *http.Request, n
 	instruments := i.WithTransaction(name, txn)
 	ctx := i.SetInstrumentsOnContext(r.Context(), instruments)
 	r = r.WithContext(ctx)
+
 	timer := instruments.StartNoTracingTimer("requests", name)
 
 	res := negroni.NewResponseWriter(rw)
@@ -288,11 +192,11 @@ func (i *fullInstruments) NoticeError(e error) {
 }
 
 // WithOfflineTransaction Will start a new transaction with a similar name to the
-// parent transaction. This method is mainly used to track code that is runinng
+// parent transaction. This method is mainly used to track code that is running
 // in goroutines other than the one that spun the first transaction.
 func (i *fullInstruments) WithOfflineTransaction(f func(Instruments)) {
 	name := "(offline)" + i.txnName
-	txn := i.config.Tracer.NewTransaction(name, nil, nil)
+	txn := i.config.Tracer.StartTransaction(name, nil, nil)
 	defer txn.End()
 
 	instruments := i.config.WithTransaction(name, txn)
@@ -312,7 +216,7 @@ type Timer struct {
 	fields      FieldsList
 	tags        TagsList
 	instruments Instruments
-	segment     Segment
+	segment     *newrelic.Segment
 }
 
 // StartTimer returns a Timer that can be stoped at the end of an operation
@@ -330,7 +234,7 @@ func (i *fullInstruments) StartTimer(c Category, name string) *Timer {
 		instruments: i,
 		tags:        TagsList{},
 		fields:      FieldsList{},
-		segment:     i.nrTransaction.StartSegment(string(c) + "::" + name),
+		segment:     newrelic.StartSegment(i.nrTransaction, name),
 	}
 }
 
@@ -349,7 +253,7 @@ func (i *fullInstruments) StartTimerWithTags(c Category, name string, tags TagsL
 		start:       time.Now(),
 		instruments: i,
 		tags:        tags,
-		segment:     i.nrTransaction.StartSegment(segmentName),
+		segment:     newrelic.StartSegment(i.nrTransaction, segmentName),
 	}
 }
 
@@ -363,7 +267,7 @@ func (i *fullInstruments) StartNoTracingTimer(c Category, name string) *Timer {
 		instruments: i,
 		tags:        TagsList{},
 		fields:      FieldsList{},
-		segment:     NoSegment{},
+		segment:     nil,
 	}
 }
 
@@ -457,6 +361,10 @@ func (i *fullInstruments) RecordEvent(c Category, name string, fields FieldsList
 	})
 }
 
+func (i *fullInstruments) GetTransaction() newrelic.Transaction {
+	return i.nrTransaction
+}
+
 func copyFields(fields FieldsList) FieldsList {
 	newList := FieldsList{}
 	for k, v := range fields {
@@ -486,11 +394,11 @@ func NewMockedInstruments() Instruments {
 
 	return &fullInstruments{
 		influxdb:      recorder,
-		nrTransaction: NoTransaction{},
+		nrTransaction: nil,
 		txnName:       "test_txn",
 		config: &InstrumentsConfig{
 			StatsRecorder: recorder,
-			Tracer:        WithoutNewRelic{},
+			Tracer:       nil,
 		},
 	}
 }
@@ -531,7 +439,7 @@ func (n NoInstruments) StartTimerWithTags(c Category, name string, tags TagsList
 		instruments: n,
 		tags:        tags,
 		fields:      FieldsList{},
-		segment:     NoSegment{},
+		segment:     nil,
 	}
 }
 
@@ -543,4 +451,8 @@ func (n NoInstruments) WithResultTiming(c Category, name string, t TagsList, f f
 // WithOfflineTransaction will call the passed function with NoInstruments
 func (n NoInstruments) WithOfflineTransaction(f func(Instruments)) {
 	f(n)
+}
+
+func (n NoInstruments) GetTransaction() newrelic.Transaction {
+	return nil
 }

--- a/instrument.go
+++ b/instrument.go
@@ -292,9 +292,7 @@ func (i *fullInstruments) StartNoTracingTimer(c Category, name string) *Timer {
 //
 // Its intended use is `defer instruments.StartTimer("my_action").End()`
 func (t *Timer) End() {
-	if t.segment != nil {
-		defer t.segment.End()
-	}
+	defer t.segment.End()
 	took := time.Since(t.start)
 
 	newTagList := copyTags(t.tags)

--- a/instrument.go
+++ b/instrument.go
@@ -273,7 +273,9 @@ func (i *fullInstruments) StartNoTracingTimer(c Category, name string) *Timer {
 //
 // Its intended use is `defer instruments.StartTimer("my_action").End()`
 func (t *Timer) End() {
-	defer t.segment.End()
+	if t.segment != nil {
+		defer t.segment.End()
+	}
 	took := time.Since(t.start)
 
 	newTagList := copyTags(t.tags)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,52 +27,16 @@
 			"revisionTime": "2017-03-08T22:38:46Z"
 		},
 		{
-			"checksumSHA1": "7WUVWIJoEjmz3eygTF+qHwG53z0=",
+			"checksumSHA1": "wUH5SD5GD4zv2Q2e+9RJkJC8qxg=",
 			"path": "github.com/newrelic/go-agent",
-			"revision": "a5d75f2b4787aa1bbc76688187b2353f8ff581a6",
-			"revisionTime": "2018-05-03T18:42:24Z"
+			"revision": "46d73e6be8b4faeee70850d0df829e4fe00d6819",
+			"revisionTime": "2018-08-28T16:38:49Z"
 		},
 		{
 			"checksumSHA1": "ys0np4OSuL68Ns95DYcnz1wSm80=",
 			"path": "github.com/newrelic/go-agent/_integrations/nrlogrus",
-			"revision": "a5d75f2b4787aa1bbc76688187b2353f8ff581a6",
-			"revisionTime": "2018-05-03T18:42:24Z"
-		},
-		{
-			"checksumSHA1": "EyMtsoF9d/C+Lh3udFlw0fzcsbA=",
-			"path": "github.com/newrelic/go-agent/internal",
-			"revision": "a5d75f2b4787aa1bbc76688187b2353f8ff581a6",
-			"revisionTime": "2018-05-03T18:42:24Z"
-		},
-		{
-			"checksumSHA1": "vIJ3Ks0FTwtzyWrLR9hCh3eo0Mw=",
-			"path": "github.com/newrelic/go-agent/internal/cat",
-			"revision": "a5d75f2b4787aa1bbc76688187b2353f8ff581a6",
-			"revisionTime": "2018-05-03T18:42:24Z"
-		},
-		{
-			"checksumSHA1": "mkbupMdy+cF7xyo8xW0A6Bq15k4=",
-			"path": "github.com/newrelic/go-agent/internal/jsonx",
-			"revision": "a5d75f2b4787aa1bbc76688187b2353f8ff581a6",
-			"revisionTime": "2018-05-03T18:42:24Z"
-		},
-		{
-			"checksumSHA1": "ywxlVKtGArJ2vDfH1rAqEFwSGds=",
-			"path": "github.com/newrelic/go-agent/internal/logger",
-			"revision": "a5d75f2b4787aa1bbc76688187b2353f8ff581a6",
-			"revisionTime": "2018-05-03T18:42:24Z"
-		},
-		{
-			"checksumSHA1": "UrKUDjmw5vdff+izBrdZRiChPSI=",
-			"path": "github.com/newrelic/go-agent/internal/sysinfo",
-			"revision": "a5d75f2b4787aa1bbc76688187b2353f8ff581a6",
-			"revisionTime": "2018-05-03T18:42:24Z"
-		},
-		{
-			"checksumSHA1": "aG3o84sokPnpJn0hOoiPbiPvOkA=",
-			"path": "github.com/newrelic/go-agent/internal/utilization",
-			"revision": "a5d75f2b4787aa1bbc76688187b2353f8ff581a6",
-			"revisionTime": "2018-05-03T18:42:24Z"
+			"revision": "46d73e6be8b4faeee70850d0df829e4fe00d6819",
+			"revisionTime": "2018-08-28T16:38:49Z"
 		},
 		{
 			"checksumSHA1": "cJM8GwMbLR6/jE58CR5HDcCpJ3c=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,6 +39,36 @@
 			"revisionTime": "2018-08-28T16:38:49Z"
 		},
 		{
+			"checksumSHA1": "ys0np4OSuL68Ns95DYcnz1wSm80=",
+			"path": "github.com/newrelic/go-agent/_integrations/nrlogrus",
+			"revision": "46d73e6be8b4faeee70850d0df829e4fe00d6819",
+			"revisionTime": "2018-08-28T16:38:49Z"
+		},
+		{
+			"checksumSHA1": "IXrIWyJEa93VHQuZHO35Fk2CAj4=",
+			"path": "github.com/newrelic/go-agent/internal",
+			"revision": "46d73e6be8b4faeee70850d0df829e4fe00d6819",
+			"revisionTime": "2018-08-28T16:38:49Z"
+		},
+		{
+			"checksumSHA1": "vIJ3Ks0FTwtzyWrLR9hCh3eo0Mw=",
+			"path": "github.com/newrelic/go-agent/internal/cat",
+			"revision": "46d73e6be8b4faeee70850d0df829e4fe00d6819",
+			"revisionTime": "2018-08-28T16:38:49Z"
+		},
+		{
+			"checksumSHA1": "mkbupMdy+cF7xyo8xW0A6Bq15k4=",
+			"path": "github.com/newrelic/go-agent/internal/jsonx",
+			"revision": "46d73e6be8b4faeee70850d0df829e4fe00d6819",
+			"revisionTime": "2018-08-28T16:38:49Z"
+		},
+		{
+			"checksumSHA1": "ywxlVKtGArJ2vDfH1rAqEFwSGds=",
+			"path": "github.com/newrelic/go-agent/internal/logger",
+			"revision": "46d73e6be8b4faeee70850d0df829e4fe00d6819",
+			"revisionTime": "2018-08-28T16:38:49Z"
+		},
+		{
 			"checksumSHA1": "cJM8GwMbLR6/jE58CR5HDcCpJ3c=",
 			"path": "github.com/seatgeek/telemetria",
 			"revision": "99522d39fc40b9578fb96600dd5719550cd8131c",


### PR DESCRIPTION
This makes the following changes:
- Expose `newrelic.Transaction` in `Instruments`, rather than the custom wrapped version, which is removed. This makes integrating with other libraries easier
- `NewTransaction` has been replaced by `StartTransaction`
- Segments are now pointers